### PR TITLE
Sync with the actual content in the cheatsheet

### DIFF
--- a/github/gist-search-cheatsheet.md
+++ b/github/gist-search-cheatsheet.md
@@ -11,7 +11,7 @@ tags:
 
 This search | Finds repositories with…
 --- | ---
-`cat stars:\>100` | Find cat gists with greater than 100 stars.
+`cat stars:>100` | Find cat gists with greater than 100 stars.
 `user:defunkt` | Get all gists from the user defunkt.
 `cat anon:true` | Include anonymous gists in your search for cat-related gists.
 `NOT cat` | Excludes all results containing cat.
@@ -26,7 +26,7 @@ This search | Finds gists with…
 `filename:.bashrc` | Find all gists with a ".bashrc" file.
 `cat language:html` | Find all cat gists with HTML files.
 `join extension:coffee` | Find all instances of join in gists with a coffee extension.
-`system size:\>1000` | Find all instances of system in gists containing a file larger than 1000kbs.
+`system size:>1000` | Find all instances of system in gists containing a file larger than 1000kbs.
 
 ---
 - [source](https://gist.github.com/search#search_cheatsheet_pane)


### PR DESCRIPTION
Synced with what you see at https://gist.github.com/search#search_cheatsheet_pane after clicking:

1. `prefixes`
2. `(see all)`

Filed an issue to hopefully urge GitHub to make their own pane linkable in the first place: https://github.com/isaacs/github/issues/1097